### PR TITLE
Function parse data --- add more tests

### DIFF
--- a/site/src/index.ts
+++ b/site/src/index.ts
@@ -203,7 +203,8 @@ export function averageOf(data: Array<number>): number {
  * Parse the string read from the fitbit "csv" file. This function can read the "activity" or "sleep" data as it simply
  * returns a map/dictionary of the data where the keys are the data's columns and the values are arrays containing the
  * ordered data within the rows. This function assumes that the first row of the data to be stored is immediately
- * following the header line. The end line specified will be included in the parsing.
+ * following the header line. The end line specified will be included in the parsing. Any quotations and commas within
+ * the data will be parsed out except if they exist in the header row, which contains keys for the dictionary.
  *
  * For activity data, the keys are:
  *  - Date

--- a/site/test/index.test.ts
+++ b/site/test/index.test.ts
@@ -237,6 +237,18 @@ describe('parseFitbitCsvString', () => {
     ]);
     expect(parseFitbitCsvString(testData, 0, 0)).toEqual(expectedMap);
   });
+  test('End line before start lines returns Map with keys and empty lists', () => {
+    let testData: string = `This, Is, A, Test
+        "10", "11", "12", "13"
+        "20", "21", "22", "23"`;
+    let expectedMap: Map<string, Array<string | number>> = new Map([
+      ['This', []],
+      ['Is', []],
+      ['A', []],
+      ['Test', []],
+    ]);
+    expect(parseFitbitCsvString(testData, 0, -1)).toEqual(expectedMap);
+  });
   test('One line specified to read with start/end line returns correct Map', () => {
     let testData: string = `This, Is, A, Test
         "10", "11", "12", "13"

--- a/site/test/index.test.ts
+++ b/site/test/index.test.ts
@@ -237,6 +237,18 @@ describe('parseFitbitCsvString', () => {
     ]);
     expect(parseFitbitCsvString(testData, 0, 0)).toEqual(expectedMap);
   });
+  test('Start line not index 0 returns Map with keys and empty lists', () => {
+    let testData: string = `This, Is, A, Test
+        "10", "11", "12", "13"
+        "20", "21", "22", "23"`;
+    let expectedMap: Map<string, Array<string | number>> = new Map([
+      ['"10"', []],
+      ['"11"', []],
+      ['"12"', []],
+      ['"13"', []],
+    ]);
+    expect(parseFitbitCsvString(testData, 1, 1)).toEqual(expectedMap);
+  });
   test('End line before start lines returns Map with keys and empty lists', () => {
     let testData: string = `This, Is, A, Test
         "10", "11", "12", "13"


### PR DESCRIPTION
Add two more tests
1. end line before start line
2. Test when the start is not line 0

Note that if quotes exist on the start line, which is the header row containing keys, the quotation marks are left in. 